### PR TITLE
include context in fatal errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,13 +46,14 @@ func main() {
 	})
 
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Error creating torrent client: %s\n", err)
 		os.Exit(exitErrorCreatingClient)
 	}
 
 	// Add the magnet url.
-	if t, err = client.AddMagnet(flag.Arg(0)); err != nil {
-		log.Fatal(err)
+	magent := flag.Arg(0)
+	if t, err = client.AddMagnet(magent); err != nil {
+		log.Fatalf("Error adding magnet \"%s\": %s\n", magent, err)
 		os.Exit(exitErrorAddingTorrent)
 	}
 


### PR DESCRIPTION
This includes context in fatal errors logged to help diagnose the errors.

I encountered a confusing error when running `go-peerflix`.

```
> ./go-peerflix -seed false 'magnet:?xt=urn:btih:KRWPCX3SJUM4IMM4YF5RPHL6ANPYTQPU'
2015/10/10 12:24:49 unexpected scheme: ""
```

This happened because I needed to use `-seed=false` and `-seed false` was causing the magent url to be `false`. I think it could be helpful to include the context of the call which resulted in a fatal error. Now, this error would be:

```
> ./go-peerflix -seed false 'magnet:?xt=urn:btih:KRWPCX3SJUM4IMM4YF5RPHL6ANPYTQPU'
2015/10/10 12:24:49 Error adding magnet "false": unexpected scheme: ""
```
