### PR TITLE
Minor cleanup:

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 	}
 
 	// Cli render loop.
-	for true {
+	for {
 		client.Render()
 		time.Sleep(time.Second)
 	}


### PR DESCRIPTION
Use same value for `currentProgress` throughout `Client.Render`, since it
may be changing.

Remove variable for `len(t.Conns)`, since it's only used once.

Made `percentage` a method since it's being used more than once.

Removed unnecessary `true` in infinite `for` loop in `main`.
