### PR TITLE
Prioritize the first 5% of the file when starting the torrent

### DIFF
--- a/fileEntry.go
+++ b/fileEntry.go
@@ -25,12 +25,9 @@ func (f FileEntry) Seek(offset int64, whence int) (int64, error) {
 }
 
 // NewFileReader sets up a torrent file for streaming reading.
-func NewFileReader(c Client, f torrent.File) (SeekableContent, error) {
+func NewFileReader(c Client, f *torrent.File) (SeekableContent, error) {
 	// We read ahead 1% of the file continuously.
 	var readahead = f.Length() / 100
-
-	// We begin by prioritizing 5% of the beginning of the file.
-	f.PrioritizeRegion(f.Offset(), readahead*5)
 
 	reader := c.Torrent.NewReader()
 	reader.SetReadahead(readahead)
@@ -38,7 +35,7 @@ func NewFileReader(c Client, f torrent.File) (SeekableContent, error) {
 	_, err := reader.Seek(f.Offset(), os.SEEK_SET)
 
 	return &FileEntry{
-		File:   &f,
+		File:   f,
 		Reader: reader,
 	}, err
 }


### PR DESCRIPTION
In the past we reprioritized the beginning of the file when the first
http connection came in, that often meant the streaming couldn't be
started right away.
