### PR TITLE
Cross platform building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 go-peerflix
+builds

--- a/.goxc.json
+++ b/.goxc.json
@@ -1,0 +1,14 @@
+{
+	"ArtifactsDest": "builds",
+	"Tasks": [
+		"xc"
+	],
+	"BuildConstraints": "linux, windows, darwin",
+	"PackageVersion": "1.0.0",
+	"TaskSettings": {
+		"xc": {
+			"GOARM": "7"
+		}
+	},
+	"ConfigVersion": "0.9"
+}

--- a/README.md
+++ b/README.md
@@ -23,5 +23,21 @@ To start playing in VLC:
 go-peerflix -vlc [magnet url|torrent path|torrent url]
 ```
 
+## Build
+
+Building only for the current platform:
+
+```bash
+go build .
+```
+
+
+Building for platforms: Linux, Darwin and Windows
+
+```bash
+goxc
+```
+
+
 ## License
 [MIT](https://raw.githubusercontent.com/Sioro-Neoku/go-peerflix/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Start watching the movie while your torrent is still downloading!
 ![Working of go-peerflix](./images/demo.gif)
 
 ## Installation
+
+Download the binary from the [releases](https://github.com/Sioro-Neoku/go-peerflix/releases) page.
+
+Or in case you have golang configured you may want to install through the command:
+
 ```sh
 go get github.com/Sioro-Neoku/go-peerflix
 ```


### PR DESCRIPTION
Hi,

More people could use it if there were the compiled client available to download instead requiring install it through the golang get toll.

Also for this "task" be completed, would require you upload these compiled clients for each new release. Is a bit more work. But as I said would allow more people using it.
