### PR TITLE
Fix dependency github.com/anacrolix/torrent

### DIFF
--- a/client.go
+++ b/client.go
@@ -197,7 +197,7 @@ func (c *Client) Render() {
 	if currentProgress < t.Info().TotalLength() {
 		fmt.Printf("Download speed: %s\n", speed)
 	}
-	fmt.Printf("Connections: \t%d\n", len(t.Peers()))
+	fmt.Printf("Connections: \t%d\n", len(t.Peers))
 	//fmt.Printf("%s\n", c.RenderPieces())
 }
 


### PR DESCRIPTION
Fix #19
github.com/Sioro-Neoku/go-peerflix/client.go:200: cannot call non-function t.torrent.Peers (type map[torrent.peersKey]torrent.Peer)
