### PR TITLE
Allow specifying incoming torrent port

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,7 +45,7 @@ type Client struct {
 
 // NewClient creates a new torrent client based on a magnet or a torrent file.
 // If the torrent file is on http, we try downloading it.
-func NewClient(torrentPath string, port int, seed bool, tcp bool, maxConnections int) (client Client, err error) {
+func NewClient(torrentPath string, port int, torrentPort int, seed bool, tcp bool, maxConnections int) (client Client, err error) {
 	var t *torrent.Torrent
 	var c *torrent.Client
 
@@ -57,6 +57,7 @@ func NewClient(torrentPath string, port int, seed bool, tcp bool, maxConnections
 		NoUpload:   !seed,
 		Seed:       seed,
 		DisableTCP: !tcp,
+		ListenAddr: fmt.Sprintf(":%d", torrentPort),
 	})
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -20,13 +20,14 @@ const (
 
 func main() {
 	// Parse flags.
-	var port int
+	var port, torrentPort int
 	var seed, tcp *bool
 	var player *string
 	var maxConnections int
 
 	player = flag.String("player", "", "Open the stream with a video player ("+joinPlayerNames()+")")
 	flag.IntVar(&port, "port", 8080, "Port to stream the video on")
+	flag.IntVar(&torrentPort, "torrent-port", 6882, "Port to listen for incoming torrent connections")
 	seed = flag.Bool("seed", false, "Seed after finished downloading")
 	flag.IntVar(&maxConnections, "conn", 200, "Maximum number of connections")
 	tcp = flag.Bool("tcp", true, "Allow connections via TCP")
@@ -37,7 +38,7 @@ func main() {
 	}
 
 	// Start up the torrent client.
-	client, err := NewClient(flag.Arg(0), port, *seed, *tcp, maxConnections)
+	client, err := NewClient(flag.Arg(0), port, torrentPort, *seed, *tcp, maxConnections)
 	if err != nil {
 		log.Fatalf(err.Error())
 		os.Exit(exitErrorInClient)

--- a/main.go
+++ b/main.go
@@ -20,25 +20,22 @@ const (
 
 func main() {
 	// Parse flags.
-	var port, torrentPort int
-	var seed, tcp *bool
-	var player *string
-	var maxConnections int
-
-	player = flag.String("player", "", "Open the stream with a video player ("+joinPlayerNames()+")")
-	flag.IntVar(&port, "port", 8080, "Port to stream the video on")
-	flag.IntVar(&torrentPort, "torrent-port", 50007, "Port to listen for incoming torrent connections")
-	seed = flag.Bool("seed", false, "Seed after finished downloading")
-	flag.IntVar(&maxConnections, "conn", 200, "Maximum number of connections")
-	tcp = flag.Bool("tcp", true, "Allow connections via TCP")
+	player := flag.String("player", "", "Open the stream with a video player ("+joinPlayerNames()+")")
+	cfg := NewClientConfig()
+	flag.IntVar(&cfg.Port, "port", cfg.Port, "Port to stream the video on")
+	flag.IntVar(&cfg.TorrentPort, "torrent-port", cfg.TorrentPort, "Port to listen for incoming torrent connections")
+	flag.BoolVar(&cfg.Seed, "seed", cfg.Seed, "Seed after finished downloading")
+	flag.IntVar(&cfg.MaxConnections, "conn", cfg.MaxConnections, "Maximum number of connections")
+	flag.BoolVar(&cfg.TCP, "tcp", cfg.TCP, "Allow connections via TCP")
 	flag.Parse()
 	if len(flag.Args()) == 0 {
 		flag.Usage()
 		os.Exit(exitNoTorrentProvided)
 	}
+	cfg.TorrentPath = flag.Arg(0)
 
 	// Start up the torrent client.
-	client, err := NewClient(flag.Arg(0), port, torrentPort, *seed, *tcp, maxConnections)
+	client, err := NewClient(cfg)
 	if err != nil {
 		log.Fatalf(err.Error())
 		os.Exit(exitErrorInClient)
@@ -47,7 +44,7 @@ func main() {
 	// Http handler.
 	go func() {
 		http.HandleFunc("/", client.GetFile)
-		log.Fatal(http.ListenAndServe(":"+strconv.Itoa(port), nil))
+		log.Fatal(http.ListenAndServe(":"+strconv.Itoa(cfg.Port), nil))
 	}()
 
 	// Open selected video player
@@ -56,7 +53,7 @@ func main() {
 			for !client.ReadyForPlayback() {
 				time.Sleep(time.Second)
 			}
-			openPlayer(*player, port)
+			openPlayer(*player, cfg.Port)
 		}()
 	}
 

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	player = flag.String("player", "", "Open the stream with a video player ("+joinPlayerNames()+")")
 	flag.IntVar(&port, "port", 8080, "Port to stream the video on")
-	flag.IntVar(&torrentPort, "torrent-port", 6882, "Port to listen for incoming torrent connections")
+	flag.IntVar(&torrentPort, "torrent-port", 50007, "Port to listen for incoming torrent connections")
 	seed = flag.Bool("seed", false, "Seed after finished downloading")
 	flag.IntVar(&maxConnections, "conn", 200, "Maximum number of connections")
 	tcp = flag.Bool("tcp", true, "Allow connections via TCP")


### PR DESCRIPTION
Adds a new flag `-torrent-port` to specify the listening port for torrent connections.

However having both `port` and `torrent-port` might be confusing. How about `http-port` and `torrent-port` or `http` and `torrent`?

As of now:

```
Usage of ./go-peerflix:
  -player string
        Open the stream with a video player (VLC, MPV, MPlayer)
  -port int
        Port to stream the video on (default 8080)
  -seed
        Seed after finished downloading
  -tcp
        Allow connections via TCP (default true)
  -torrent-port int
        Port to listen for incoming torrent connections (default 6882)
```
