### PR TITLE
Show version and build date

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+# With tag: 1.0.0[-commits since tag][-dirty]
+# Without existing tags: 4a4154a[-dirty]
+version=$(git describe --tags --always --dirty)
+# 2000-12-13 13:00:00
+buildDate=$(date --utc "+%F %T")
+go build -ldflags "-X 'main.Version=$version' -X 'main.BuildDate=$buildDate'"

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"syscall"
 	"time"
+	"fmt"
 )
 
 // Exit statuses.
@@ -17,6 +18,9 @@ const (
 	exitNoTorrentProvided
 	exitErrorInClient
 )
+
+var Version = ""
+var BuildDate = ""
 
 func main() {
 	// Parse flags.
@@ -28,6 +32,7 @@ func main() {
 	flag.IntVar(&port, "port", 8080, "Port to stream the video on")
 	seed = flag.Bool("seed", false, "Seed after finished downloading")
 	tcp = flag.Bool("tcp", true, "Allow connections via TCP")
+	printVersion()
 	flag.Parse()
 	if len(flag.Args()) == 0 {
 		flag.Usage()
@@ -78,4 +83,15 @@ func main() {
 		client.Render()
 		time.Sleep(time.Second)
 	}
+}
+
+func printVersion() {
+	fmt.Print("go-peerflix")
+	if Version != "" {
+		fmt.Printf(" %s", Version)
+	}
+	if BuildDate != "" {
+		fmt.Printf(" (%s)", BuildDate)
+	}
+	fmt.Print("\n\n")
 }


### PR DESCRIPTION
Just to prepare for potential tagged releases and to make it easier to check that you're up to date.

Without any tags in a dirty working directory:

```
go-peerflix 4a4154a-dirty (2016-03-07 20:53:38)

Usage of ./go-peerflix:
...
```

When building _directly_ from a tagged revision, it should look like this:

```
go-peerflix 1.0.0 (2016-03-07 20:53:38)
```
