### PR TITLE
Added custom port entry to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Access the stream on [http://localhost:8080/](http://localhost:8080/)
 go-peerflix [magnet url|torrent path|torrent url]
 ```
 
+To use a custom port, pass the -port flag
+```sh
+go-peerflix -port 9000 [magent url|torrent path|torrent url]
+```
+
 To start playing in VLC:
 ```sh
 go-peerflix -player vlc [magnet url|torrent path|torrent url]


### PR DESCRIPTION
I didn't know go-peerflix had this capability so I went to try and implement my own, then I saw it in the source. I think it should be in the readme.
