### PR TITLE
Open selected file

### DIFF
--- a/client.go
+++ b/client.go
@@ -315,9 +315,9 @@ func (c Client) SelectFile() *torrent.File {
 	}
 	fmt.Println()
 	w := tabwriter.NewWriter(os.Stdout, 1, 4, 1, ' ', 0)
-	fmt.Fprintln(w, "#\tPath\tSize (MB)")
+	fmt.Fprintln(w, "#\tPath\tSize")
 	for i, file := range candidates {
-		fmt.Fprintf(w, "%d\t%s\t%d\n", i, file.DisplayPath(), file.Length()/1024/1024)
+		fmt.Fprintf(w, "%d\t%s\t%s\n", i, file.DisplayPath(), humanize.Bytes(uint64(file.Length())))
 	}
 	w.Flush()
 	pos := -1

--- a/client.go
+++ b/client.go
@@ -319,7 +319,10 @@ func (c Client) SelectFile() *torrent.File {
 	for i, file := range candidates {
 		fmt.Fprintf(w, "%d\t%s\t%s\n", i, file.DisplayPath(), humanize.Bytes(uint64(file.Length())))
 	}
-	w.Flush()
+	err := w.Flush()
+	if err != nil {
+		log.Println(err)
+	}
 	pos := -1
 	for pos < 0 || pos >= len(candidates) {
 		fmt.Println()

--- a/main.go
+++ b/main.go
@@ -47,16 +47,6 @@ func main() {
 		log.Fatal(http.ListenAndServe(":"+strconv.Itoa(cfg.Port), nil))
 	}()
 
-	// Open selected video player
-	if *player != "" {
-		go func() {
-			for !client.ReadyForPlayback() {
-				time.Sleep(time.Second)
-			}
-			openPlayer(*player, cfg.Port)
-		}()
-	}
-
 	// Handle exit signals.
 	interruptChannel := make(chan os.Signal, 1)
 	signal.Notify(interruptChannel,
@@ -72,6 +62,14 @@ func main() {
 			os.Exit(0)
 		}
 	}(interruptChannel)
+
+	<-client.Torrent.GotInfo()
+	log.Printf("Now streaming: %s", client.Torrent.Name())
+
+	// Open selected video player
+	if *player != "" {
+		openPlayer(*player, cfg.Port, client.SelectFile().DisplayPath())
+	}
 
 	// Cli render loop.
 	for {

--- a/player.go
+++ b/player.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"net/url"
 	"os/exec"
 	"runtime"
-	"strconv"
 	"strings"
 )
 
@@ -36,8 +37,8 @@ func (p GenericPlayer) Open(url string) error {
 	return exec.Command(command[0], command[1:]...).Start()
 }
 
-// openPlayer opens a stream using the specified player and port.
-func openPlayer(playerName string, port int) {
+// openPlayer opens a stream using the specified player, port and file path.
+func openPlayer(playerName string, port int, file string) {
 	var player Player
 	playerName = strings.ToLower(playerName)
 	for _, genericPlayer := range genericPlayers {
@@ -49,8 +50,9 @@ func openPlayer(playerName string, port int) {
 		log.Printf("Player '%s' is not supported. Currently supported players are: %s", playerName, joinPlayerNames())
 		return
 	}
-	log.Printf("Playing in %s", playerName)
-	if err := player.Open("http://localhost:" + strconv.Itoa(port)); err != nil {
+	uri := fmt.Sprintf("http://localhost:%d/%s", port, url.QueryEscape(file))
+	log.Printf("Playing in %s: %s", playerName, uri)
+	if err := player.Open(uri); err != nil {
 		log.Printf("Error opening %s: %s\n", playerName, err)
 	}
 }


### PR DESCRIPTION
- The HTTP handler now returns a Reader for a file within the torrent as specified by the request URI.
- If there are multiple videos, the user is asked to select one.
- In any case video players now request specific files instead of just the root directory.

Fixes #26 #36

So far it's working fine for me. Note that the progress is not accurate yet, as it still uses the total torrent size.