### PR TITLE
Fix error caused by upstream torrent updates

### DIFF
--- a/fileEntry.go
+++ b/fileEntry.go
@@ -16,20 +16,7 @@ type SeekableContent interface {
 // FileEntry helps reading a torrent file.
 type FileEntry struct {
 	*torrent.File
-	Reader *torrent.Reader
-}
-
-// Seek seeks to the correct file position, paying attention to the offset.
-func (f FileEntry) Seek(offset int64, whence int) (int64, error) {
-	return (*f.Reader).Seek(offset+f.File.Offset(), whence)
-}
-
-func (f FileEntry) Read(p []byte) (n int, err error) {
-	return (*f.Reader).Read(p)
-}
-
-func (f FileEntry) Close() error {
-	return (*f.Reader).Close()
+	torrent.Reader
 }
 
 // NewFileReader sets up a torrent file for streaming reading.
@@ -44,6 +31,6 @@ func NewFileReader(f *torrent.File) (SeekableContent, error) {
 
 	return &FileEntry{
 		File:   f,
-		Reader: &reader,
+		Reader: reader,
 	}, err
 }

--- a/fileEntry.go
+++ b/fileEntry.go
@@ -16,12 +16,20 @@ type SeekableContent interface {
 // FileEntry helps reading a torrent file.
 type FileEntry struct {
 	*torrent.File
-	*torrent.Reader
+	Reader *torrent.Reader
 }
 
 // Seek seeks to the correct file position, paying attention to the offset.
 func (f FileEntry) Seek(offset int64, whence int) (int64, error) {
-	return f.Reader.Seek(offset+f.File.Offset(), whence)
+	return (*f.Reader).Seek(offset+f.File.Offset(), whence)
+}
+
+func (f FileEntry) Read(p []byte) (n int, err error) {
+	return (*f.Reader).Read(p)
+}
+
+func (f FileEntry) Close() error {
+	return (*f.Reader).Close()
 }
 
 // NewFileReader sets up a torrent file for streaming reading.
@@ -36,6 +44,6 @@ func NewFileReader(f *torrent.File) (SeekableContent, error) {
 
 	return &FileEntry{
 		File:   f,
-		Reader: reader,
+		Reader: &reader,
 	}, err
 }


### PR DESCRIPTION
1. Fix torrent.ClientConfig error, passing ipblocklist from config
2. PrioritizeRegion method is removed from torrent.File. Reimplement the logic
3. torrent.Reader is changed from struct to interface. Update fileEntry correspondingly