### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang
+
+COPY . /usr/src/go-peerflix/
+WORKDIR /usr/src/go-peerflix/
+
+RUN go build .
+
+ENTRYPOINT [ "./go-peerflix" ]


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Golang image, latest tag. More info at https://hub.docker.com/_/golang/.
No Golang install needed on systems with Docker, both for running or for developing/testing.

Just adding files, setting working dir and running build instructions, nothing fancy here.

Build:

```
$ docker build -t go-peerflix .
```

Run:

```
$ docker run --rm -it -p 8080:8080 go-peerflix [other options...]
```
Using the `-p`switch to open/map ports. Add as many `-p`options as needed. Alternatively, you can use `--net=host` to give the container full access to the local networking stack, instead of mapping ports.

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it -p 8080:8080 pataquets/go-peerflix-src [other options...]
```

`CTRL+C`'ing stops it. Using `--rm` causes the container to be deleted after running.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a ~free~ paid Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed. This would add an easy, container-friendly distribution method and can also provide a kind of 'daily' test builds. Both stable and latest/edge/dev versions are possible via branches/tags.